### PR TITLE
Renames jQuery scripts for better clarity

### DIFF
--- a/woocommerce-product-country-base-restrictions.php
+++ b/woocommerce-product-country-base-restrictions.php
@@ -291,8 +291,8 @@ class ZH_Product_Country_Restrictions {
 		wp_register_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), WC_VERSION );
 		wp_enqueue_style( 'woocommerce_admin_styles' );
 	
-		wp_register_script( 'jquery-tiptip', WC()->plugin_url() . '/assets/js/jquery-tiptip/jquery.tipTip.min.js', array( 'jquery' ), WC_VERSION, true );
-		wp_enqueue_script( 'jquery-tiptip' );
+		wp_register_script( 'wc-jquery-tiptip', WC()->plugin_url() . '/assets/js/jquery-tiptip/jquery.tipTip.min.js', array( 'jquery' ), WC_VERSION, true );
+		wp_enqueue_script( 'wc-jquery-tiptip' );
 		
 	}
 	

--- a/zorem-tracking/zorem-tracking.php
+++ b/zorem-tracking/zorem-tracking.php
@@ -83,8 +83,8 @@ if ( !class_exists( 'WC_Trackers' ) ) {
 		public function enqueue_plugin_styles() {
 			// Enqueue your CSS file
 			$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-			wp_register_script( 'jquery-blockui', WC()->plugin_url() . '/assets/js/jquery-blockui/jquery.blockUI' . $suffix . '.js', array( 'jquery' ), '2.70', true );
-			wp_enqueue_script( 'jquery-blockui' );
+			wp_register_script( 'wc-jquery-blockui', WC()->plugin_url() . '/assets/js/jquery-blockui/jquery.blockUI' . $suffix . '.js', array( 'jquery' ), '2.70', true );
+			wp_enqueue_script( 'wc-jquery-blockui' );
 			wp_enqueue_style('plugin-css', plugin_dir_url(__FILE__) . 'assets/css/style.css', array(), time());
 			wp_enqueue_script('plugin-js', plugin_dir_url(__FILE__) . 'assets/js/main.js', array(), time());
 			 


### PR DESCRIPTION
Renames registered jQuery scripts to include the 'wc-' prefix. This improves clarity and avoids potential conflicts with other plugins or themes that might use the same script names.